### PR TITLE
deprecate set-output command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ runs:
     - id: get-terraform-version
       run: |
         result=$(${{ github.action_path }}/src/main.sh ${{ inputs.path }})
-        echo "::set-output name=terraform-version::$(echo $result)"
+        echo "terraform-version=$result" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

this PR removes a warning received while using this action. thanks for the awesome action =)